### PR TITLE
fix android atomic

### DIFF
--- a/daabbcc/ext.manifest
+++ b/daabbcc/ext.manifest
@@ -4,4 +4,4 @@ name: "DAABBCC"
 platforms:
     common:
        context:
-           flags: ["-std=c++17"]
+           flags: ["-std=c++11"]

--- a/daabbcc/ext.manifest
+++ b/daabbcc/ext.manifest
@@ -4,4 +4,4 @@ name: "DAABBCC"
 platforms:
     common:
        context:
-           flags: ["-std=c++11"]
+           flags: ["-std=c++17"]

--- a/daabbcc/src/daabbcc/core.cpp
+++ b/daabbcc/src/daabbcc/core.cpp
@@ -11,12 +11,7 @@
 #include <stdlib.h>
 #endif
 
-
-#if defined(B2_PLATFORM_ANDROID)
-#include <atomic> 
-#else
 #include <stdatomic.h>
-#endif
 
 #include <string.h>
 
@@ -42,6 +37,22 @@ namespace daabbcc
     // This allows the user to change the length units at runtime
     float b2_lengthUnitsPerMeter = 1.0f;
 
+    typedef struct b2AtomicInt
+    {
+        int value;
+    } b2AtomicInt;
+
+    int b2AtomicFetchAddInt( b2AtomicInt* a, int increment )
+    {
+        #if defined( _MSC_VER )
+        return _InterlockedExchangeAdd( (long*)&a->value, (long)increment );
+        #elif defined( __GNUC__ ) || defined( __clang__ )
+        return __atomic_fetch_add( &a->value, increment, __ATOMIC_SEQ_CST );
+        #else
+        #error "Unsupported platform"
+        #endif
+    }
+    
     void  b2SetLengthUnitsPerMeter(float lengthUnits)
     {
         B2_ASSERT(b2IsValidFloat(lengthUnits) && lengthUnits > 0.0f);
@@ -77,11 +88,7 @@ namespace daabbcc
     static b2AllocFcn* b2_allocFcn = NULL;
     static b2FreeFcn*  b2_freeFcn = NULL;
 
-    #if defined(B2_PLATFORM_ANDROID)
-    std::atomic<int> b2_byteCount;
-    #else
-    static _Atomic int b2_byteCount;
-    #endif
+    b2AtomicInt b2_byteCount;
 
     void               b2SetAllocator(b2AllocFcn* allocFcn, b2FreeFcn* freeFcn)
     {
@@ -100,11 +107,9 @@ namespace daabbcc
         }
 
         // This could cause some sharing issues, however Box2D rarely calls b2Alloc.
-        #if defined(B2_PLATFORM_ANDROID)
-        b2_byteCount.fetch_add(size, std::memory_order_relaxed);
-        #else
-        atomic_fetch_add_explicit(&b2_byteCount, size, memory_order_relaxed);
-        #endif
+        b2AtomicFetchAddInt( &b2_byteCount, size );
+        //atomic_fetch_add_explicit(&b2_byteCount, size, memory_order_relaxed);
+
 
         // Allocation must be a multiple of 32 or risk a seg fault
         // https://en.cppreference.com/w/c/memory/aligned_alloc
@@ -163,12 +168,9 @@ namespace daabbcc
             free(mem);
 #endif
         }
-
-        #if defined(B2_PLATFORM_ANDROID)
-        b2_byteCount.fetch_sub(size, std::memory_order_relaxed);
-        #else
-        atomic_fetch_sub_explicit(&b2_byteCount, size, memory_order_relaxed);
-        #endif    
+        b2AtomicFetchAddInt( &b2_byteCount, -size );
+        //atomic_fetch_sub_explicit(&b2_byteCount, size, memory_order_relaxed);
+     
     }
 
 } // namespace daabbcc

--- a/daabbcc/src/daabbcc/core.cpp
+++ b/daabbcc/src/daabbcc/core.cpp
@@ -11,7 +11,13 @@
 #include <stdlib.h>
 #endif
 
+
+#if defined(B2_PLATFORM_ANDROID)
+#include <atomic> 
+#else
 #include <stdatomic.h>
+#endif
+
 #include <string.h>
 
 #ifdef BOX2D_PROFILE
@@ -71,7 +77,11 @@ namespace daabbcc
     static b2AllocFcn* b2_allocFcn = NULL;
     static b2FreeFcn*  b2_freeFcn = NULL;
 
+    #if defined(B2_PLATFORM_ANDROID)
+    std::atomic<int> b2_byteCount;
+    #else
     static _Atomic int b2_byteCount;
+    #endif
 
     void               b2SetAllocator(b2AllocFcn* allocFcn, b2FreeFcn* freeFcn)
     {
@@ -90,7 +100,11 @@ namespace daabbcc
         }
 
         // This could cause some sharing issues, however Box2D rarely calls b2Alloc.
+        #if defined(B2_PLATFORM_ANDROID)
+        b2_byteCount.fetch_add(size, std::memory_order_relaxed);
+        #else
         atomic_fetch_add_explicit(&b2_byteCount, size, memory_order_relaxed);
+        #endif
 
         // Allocation must be a multiple of 32 or risk a seg fault
         // https://en.cppreference.com/w/c/memory/aligned_alloc
@@ -150,7 +164,11 @@ namespace daabbcc
 #endif
         }
 
+        #if defined(B2_PLATFORM_ANDROID)
+        b2_byteCount.fetch_sub(size, std::memory_order_relaxed);
+        #else
         atomic_fetch_sub_explicit(&b2_byteCount, size, memory_order_relaxed);
+        #endif    
     }
 
 } // namespace daabbcc

--- a/daabbcc/src/daabbcc/core.cpp
+++ b/daabbcc/src/daabbcc/core.cpp
@@ -12,7 +12,6 @@
 #endif
 
 #include <stdatomic.h>
-
 #include <string.h>
 
 #ifdef BOX2D_PROFILE
@@ -108,8 +107,6 @@ namespace daabbcc
 
         // This could cause some sharing issues, however Box2D rarely calls b2Alloc.
         b2AtomicFetchAddInt( &b2_byteCount, size );
-        //atomic_fetch_add_explicit(&b2_byteCount, size, memory_order_relaxed);
-
 
         // Allocation must be a multiple of 32 or risk a seg fault
         // https://en.cppreference.com/w/c/memory/aligned_alloc
@@ -169,7 +166,6 @@ namespace daabbcc
 #endif
         }
         b2AtomicFetchAddInt( &b2_byteCount, -size );
-        //atomic_fetch_sub_explicit(&b2_byteCount, size, memory_order_relaxed);
      
     }
 


### PR DESCRIPTION
Hi, I got problem on android build. 
Add using cpp atomics in Android

stack trace
```upload/daabbcc/src/daabbcc/core.cpp:93:9: error: no matching function for call to 'atomic_fetch_add_explicit'
        atomic_fetch_add_explicit(&b2_byteCount, size, memory_order_relaxed);
        ^~~~~~~~~~~~~~~~~~~~~~~~~
/opt/platformsdk/android/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/atomic:2183:1: note: candidate template ignored: could not match 'volatile atomic<_Tp>' against '_Atomic(int)'
atomic_fetch_add_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
^
/opt/platformsdk/android/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/atomic:2195:1: note: candidate template ignored: could not match 'atomic<_Tp>' against '_Atomic(int)'
atomic_fetch_add_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
^
/opt/platformsdk/android/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/atomic:2203:1: note: candidate template ignored: could not match 'volatile atomic<_Tp *>' against '_Atomic(int)'
atomic_fetch_add_explicit(volatile atomic<_Tp*>* __o, ptrdiff_t __op,
^
/opt/platformsdk/android/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/atomic:2212:1: note: candidate template ignored: could not match 'atomic<_Tp *>' against '_Atomic(int)'
atomic_fetch_add_explicit(atomic<_Tp*>* __o, ptrdiff_t __op, memory_order __m) _NOEXCEPT
^
upload/daabbcc/src/daabbcc/core.cpp:153:9: error: no matching function for call to 'atomic_fetch_sub_explicit'
        atomic_fetch_sub_explicit(&b2_byteCount, size, memory_order_relaxed);
        ^~~~~~~~~~~~~~~~~~~~~~~~~
/opt/platformsdk/android/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/atomic:2268:1: note: candidate template ignored: could not match 'volatile atomic<_Tp>' against '_Atomic(int)'
atomic_fetch_sub_explicit(volatile atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
^
/opt/platformsdk/android/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/atomic:2280:1: note: candidate template ignored: could not match 'atomic<_Tp>' against '_Atomic(int)'
atomic_fetch_sub_explicit(atomic<_Tp>* __o, _Tp __op, memory_order __m) _NOEXCEPT
^
/opt/platformsdk/android/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/atomic:2288:1: note: candidate template ignored: could not match 'volatile atomic<_Tp *>' against '_Atomic(int)'
atomic_fetch_sub_explicit(volatile atomic<_Tp*>* __o, ptrdiff_t __op,
^
/opt/platformsdk/android/android-ndk-r25b/toolchains/llvm/prebuilt/linux-x86_64/bin/../sysroot/usr/include/c++/v1/atomic:2297:1: note: candidate template ignored: could not match 'atomic<_Tp *>' against '_Atomic(int)'
atomic_fetch_sub_explicit(atomic<_Tp*>* __o, ptrdiff_t __op, memory_order __m) _NOEXCEPT
^
2 errors generated.
```