### PR TITLE
Create ext.properties

### DIFF
--- a/daabbcc/ext.properties
+++ b/daabbcc/ext.properties
@@ -1,0 +1,13 @@
+[daabbcc]
+title = DAABBCC
+group = Runtime
+help = Settings for DAABBCC extension
+
+max_group_count.type = integer
+max_group_count.default = 3
+
+max_gameobject_count.type = integer
+max_gameobject_count.default = 128
+
+max_query_result_count.type = integer
+max_query_result_count.default = 32


### PR DESCRIPTION
[Soon](https://github.com/defold/defold/pull/11125), it will be possible to show extension settings in the `game.project` form. This PR adds `ext.properties` to show used settings:
<img width="646" height="778" alt="Screenshot 2025-08-22 at 15 36 52" src="https://github.com/user-attachments/assets/5ad22866-f731-427f-a98f-d5c330625e15" />
